### PR TITLE
fix(app): handle yt-dlp returning no metadata

### DIFF
--- a/app/stream_harvestarr.py
+++ b/app/stream_harvestarr.py
@@ -549,7 +549,15 @@ class StreamHarvester(object):
                 )
         except Exception as e:
             logger.error(e)
+            return False, ''
         else:
+            # ignoreerrors makes yt-dlp log and swallow extraction failures
+            # and return None rather than raise. A playlist entry with a null
+            # title trips yt-dlp's own matchtitle regex, so any playlist
+            # holding an unavailable video reaches this.
+            if result is None:
+                logger.error('No metadata returned for {}'.format(playlist))
+                return False, ''
             video_url = None
             # Prefer webpage_url over url: yt-dlp's YouTube extractor only sets
             # url when format selection picks a single non-merge format. HLS

--- a/app/stream_harvestarr.py
+++ b/app/stream_harvestarr.py
@@ -552,7 +552,7 @@ class StreamHarvester(object):
             return False, ''
         else:
             # ignoreerrors makes yt-dlp swallow errors and return None: a null
-            # entry title trips its own matchtitle regex. See issue #149.
+            # entry title trips its own matchtitle regex.
             if result is None:
                 logger.error('No metadata returned for {}'.format(playlist))
                 return False, ''

--- a/app/stream_harvestarr.py
+++ b/app/stream_harvestarr.py
@@ -551,10 +551,8 @@ class StreamHarvester(object):
             logger.error(e)
             return False, ''
         else:
-            # ignoreerrors makes yt-dlp log and swallow extraction failures
-            # and return None rather than raise. A playlist entry with a null
-            # title trips yt-dlp's own matchtitle regex, so any playlist
-            # holding an unavailable video reaches this.
+            # ignoreerrors makes yt-dlp swallow errors and return None: a null
+            # entry title trips its own matchtitle regex. See issue #149.
             if result is None:
                 logger.error('No metadata returned for {}'.format(playlist))
                 return False, ''

--- a/test/test_ytsearch_missing_metadata.py
+++ b/test/test_ytsearch_missing_metadata.py
@@ -1,0 +1,100 @@
+"""
+Unit tests for ``ytsearch()`` when yt-dlp hands back no metadata.
+
+``ignoreerrors`` makes yt-dlp log and swallow extraction failures and return
+None from ``extract_info`` rather than raise. That is reachable on any playlist
+holding a video with a null title, which trips yt-dlp's own ``matchtitle``
+regex ("expected string or bytes-like object, got 'NoneType'"). ``ytsearch()``
+has to report "not found" instead of raising, or the exception escapes
+``main()``, kills the scheduler, and the container restart-loops.
+
+These exercise the *actual* method on the shipped class rather than a local
+copy, so the tests stay bound to the real code path.
+"""
+import os
+import sys
+import unittest
+
+APP_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'app'))
+sys.path.insert(0, APP_DIR)
+
+# stream_harvestarr reads CONFIGPATH and parses argv at import time, and
+# setup_logging() opens ../logs/stream_harvestarr.log. Satisfy all three
+# before importing; no config file is read until StreamHarvester() is built.
+os.environ.setdefault('CONFIGPATH', os.path.join(APP_DIR, '..', 'config', 'config.yml'))
+os.makedirs(os.path.join(APP_DIR, '..', 'logs'), exist_ok=True)
+sys.argv = sys.argv[:1]
+
+import stream_harvestarr  # noqa: E402
+
+PLAYLIST = 'https://www.youtube.com/playlist?list=TEST'
+
+
+class FakeYoutubeDL(object):
+    """Minimal yt_dlp.YoutubeDL stand-in usable as a context manager."""
+
+    def __init__(self, result=None, exc=None):
+        self.result = result
+        self.exc = exc
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+    def extract_info(self, url, download=False):
+        if self.exc is not None:
+            raise self.exc
+        return self.result
+
+
+class TestYtsearchMissingMetadata(unittest.TestCase):
+    """ytsearch() must always return a (found, url) pair."""
+
+    def tearDown(self):
+        stream_harvestarr.yt_dlp.YoutubeDL = self._real_ydl
+
+    def setUp(self):
+        self._real_ydl = stream_harvestarr.yt_dlp.YoutubeDL
+
+    def ytsearch(self, **kwargs):
+        stream_harvestarr.yt_dlp.YoutubeDL = lambda opts: FakeYoutubeDL(**kwargs)
+        # ytsearch touches no instance state, so call it unbound rather than
+        # constructing a StreamHarvester (which needs a real config.yml).
+        return stream_harvestarr.StreamHarvester.ytsearch(None, {}, PLAYLIST)
+
+    def test_none_result_returns_not_found(self):
+        """extract_info() returning None must not raise."""
+        self.assertEqual(self.ytsearch(result=None), (False, ''))
+
+    def test_extraction_error_returns_not_found(self):
+        """A raised extraction error must not return a bare None."""
+        self.assertEqual(self.ytsearch(exc=RuntimeError('boom')), (False, ''))
+
+    def test_entries_prefers_webpage_url(self):
+        """Regression guard for issue #114 handling."""
+        result = {'entries': [{'webpage_url': 'https://youtu.be/abc', 'url': None}]}
+        self.assertEqual(self.ytsearch(result=result), (True, 'https://youtu.be/abc'))
+
+    def test_entries_skips_none_entries(self):
+        """Unavailable playlist members come back as None entries."""
+        result = {'entries': [None, {'url': 'https://youtu.be/def'}]}
+        self.assertEqual(self.ytsearch(result=result), (True, 'https://youtu.be/def'))
+
+    def test_single_video_result(self):
+        """Non-playlist results read the top-level keys."""
+        result = {'webpage_url': 'https://youtu.be/ghi'}
+        self.assertEqual(self.ytsearch(result=result), (True, 'https://youtu.be/ghi'))
+
+    def test_no_match_returns_not_found(self):
+        """An empty entries list means matchtitle filtered everything out."""
+        self.assertEqual(self.ytsearch(result={'entries': []}), (False, ''))
+
+    def test_playlist_url_echoed_back_is_not_a_match(self):
+        """yt-dlp echoing the playlist URL back is not a found episode."""
+        self.assertEqual(self.ytsearch(result={'webpage_url': PLAYLIST}), (False, ''))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_ytsearch_missing_metadata.py
+++ b/test/test_ytsearch_missing_metadata.py
@@ -1,12 +1,9 @@
 """
-Unit tests for ``ytsearch()`` when yt-dlp hands back no metadata.
+Unit tests for ``ytsearch()`` when yt-dlp hands back no metadata (issue #149).
 
-``ignoreerrors`` makes yt-dlp log and swallow extraction failures and return
-None from ``extract_info`` rather than raise. That is reachable on any playlist
-holding a video with a null title, which trips yt-dlp's own ``matchtitle``
-regex ("expected string or bytes-like object, got 'NoneType'"). ``ytsearch()``
-has to report "not found" instead of raising, or the exception escapes
-``main()``, kills the scheduler, and the container restart-loops.
+``ignoreerrors`` makes yt-dlp swallow errors and return None from
+``extract_info``; ``ytsearch()`` must report "not found" rather than raise, or
+the exception escapes ``main()`` and the container restart-loops.
 
 These exercise the *actual* method on the shipped class rather than a local
 copy, so the tests stay bound to the real code path.
@@ -19,8 +16,7 @@ APP_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'app'))
 sys.path.insert(0, APP_DIR)
 
 # stream_harvestarr reads CONFIGPATH and parses argv at import time, and
-# setup_logging() opens ../logs/stream_harvestarr.log. Satisfy all three
-# before importing; no config file is read until StreamHarvester() is built.
+# setup_logging() opens ../logs. No config file is read until __init__ runs.
 os.environ.setdefault('CONFIGPATH', os.path.join(APP_DIR, '..', 'config', 'config.yml'))
 os.makedirs(os.path.join(APP_DIR, '..', 'logs'), exist_ok=True)
 sys.argv = sys.argv[:1]
@@ -65,34 +61,34 @@ class TestYtsearchMissingMetadata(unittest.TestCase):
         return stream_harvestarr.StreamHarvester.ytsearch(None, {}, PLAYLIST)
 
     def test_none_result_returns_not_found(self):
-        """extract_info() returning None must not raise."""
+        """The issue #149 crash."""
         self.assertEqual(self.ytsearch(result=None), (False, ''))
 
     def test_extraction_error_returns_not_found(self):
-        """A raised extraction error must not return a bare None."""
+        """The except branch must not return a bare None."""
         self.assertEqual(self.ytsearch(exc=RuntimeError('boom')), (False, ''))
 
     def test_entries_prefers_webpage_url(self):
-        """Regression guard for issue #114 handling."""
+        """Issue #114 regression guard."""
         result = {'entries': [{'webpage_url': 'https://youtu.be/abc', 'url': None}]}
         self.assertEqual(self.ytsearch(result=result), (True, 'https://youtu.be/abc'))
 
     def test_entries_skips_none_entries(self):
-        """Unavailable playlist members come back as None entries."""
+        """Unavailable members come back as None entries."""
         result = {'entries': [None, {'url': 'https://youtu.be/def'}]}
         self.assertEqual(self.ytsearch(result=result), (True, 'https://youtu.be/def'))
 
     def test_single_video_result(self):
-        """Non-playlist results read the top-level keys."""
+        """Non-playlist results read top-level keys."""
         result = {'webpage_url': 'https://youtu.be/ghi'}
         self.assertEqual(self.ytsearch(result=result), (True, 'https://youtu.be/ghi'))
 
     def test_no_match_returns_not_found(self):
-        """An empty entries list means matchtitle filtered everything out."""
+        """Empty entries means matchtitle filtered everything out."""
         self.assertEqual(self.ytsearch(result={'entries': []}), (False, ''))
 
     def test_playlist_url_echoed_back_is_not_a_match(self):
-        """yt-dlp echoing the playlist URL back is not a found episode."""
+        """The playlist URL echoed back is not a found episode."""
         self.assertEqual(self.ytsearch(result={'webpage_url': PLAYLIST}), (False, ''))
 
 

--- a/test/test_ytsearch_missing_metadata.py
+++ b/test/test_ytsearch_missing_metadata.py
@@ -1,5 +1,5 @@
 """
-Unit tests for ``ytsearch()`` when yt-dlp hands back no metadata (issue #149).
+Unit tests for ``ytsearch()`` when yt-dlp hands back no metadata.
 
 ``ignoreerrors`` makes yt-dlp swallow errors and return None from
 ``extract_info``; ``ytsearch()`` must report "not found" rather than raise, or
@@ -61,7 +61,7 @@ class TestYtsearchMissingMetadata(unittest.TestCase):
         return stream_harvestarr.StreamHarvester.ytsearch(None, {}, PLAYLIST)
 
     def test_none_result_returns_not_found(self):
-        """The issue #149 crash."""
+        """A None result must not raise."""
         self.assertEqual(self.ytsearch(result=None), (False, ''))
 
     def test_extraction_error_returns_not_found(self):
@@ -69,7 +69,7 @@ class TestYtsearchMissingMetadata(unittest.TestCase):
         self.assertEqual(self.ytsearch(exc=RuntimeError('boom')), (False, ''))
 
     def test_entries_prefers_webpage_url(self):
-        """Issue #114 regression guard."""
+        """webpage_url is preferred over url."""
         result = {'entries': [{'webpage_url': 'https://youtu.be/abc', 'url': None}]}
         self.assertEqual(self.ytsearch(result=result), (True, 'https://youtu.be/abc'))
 


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows the Angular guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) — no docs impact

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #149

`ytsearch()` treats `extract_info`'s return as a dict, but it can be `None`. The `TypeError` escapes `main()`, kills the scheduler, and the container restart-loops — nothing downloads for any series. My install logged 801 crashes in 11 hours.

How it gets there:

1. A playlist holds a video with a null title (an unavailable member).
2. yt-dlp's own `_match_entry` runs `re.search(matchtitle, None)`:

   ```python
   >>> yt_dlp.YoutubeDL({'matchtitle': 'HOT ONES', 'ignoreerrors': True})._match_entry({'title': None, 'id': 'abc'})
   TypeError: expected string or bytes-like object, got 'NoneType'
   ```

   That's the bare `ERROR:` line in #149 — yt-dlp's logger, not ours.
3. `ignoreerrors: True` swallows it, so `extract_info` returns `None` and the `except` branch never runs.
4. Line 563 indexes `None`.

The trigger is a property of the playlist, not the episode, so every scan hits it again.

## What is the new behavior?

`ytsearch()` returns `(False, '')` when `extract_info` yields no metadata, so an unavailable playlist member is a skipped episode instead of a dead scheduler.

The `except` branch also returns `(False, '')`. It logged the error and then fell through to an implicit `None`, so the caller's `found, dlurl = self.ytsearch(...)` unpack raised. `ignoreerrors` hides that today, but anything raised outside yt-dlp's own handling reaches it.

No change to the found/not-found paths.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

n/a