### PR TITLE
fix(sonarr): send seriesId as int in RescanSeries

### DIFF
--- a/app/stream_harvestarr.py
+++ b/app/stream_harvestarr.py
@@ -286,7 +286,7 @@ class StreamHarvester(object):
         logger.debug('Begin call Sonarr to rescan for series_id: {}'.format(series_id))
         data = {
             "name": "RescanSeries",
-            "seriesId": str(series_id)
+            "seriesId": int(series_id)
         }
         res = self.request_put(
             "{}/{}/command".format(self.base_url, self.sonarr_api_version),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests>=2.34.2
-yt-dlp>=2026.3.17
+yt-dlp>=2026.7.4
 yt-dlp-ejs>=0.8.0
 pyyaml>=6.0.3
 schedule>=1.2.2

--- a/test/test_rescanseries_payload.py
+++ b/test/test_rescanseries_payload.py
@@ -1,0 +1,62 @@
+"""
+Unit tests for the RescanSeries command payload.
+
+Sonarr v4 types seriesId as a nullable int and rejects a JSON string with
+HTTP 500, so the rescan issued after every download failed and Sonarr never
+imported the downloaded file.
+"""
+import os
+import sys
+import unittest
+
+APP_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'app'))
+sys.path.insert(0, APP_DIR)
+
+# stream_harvestarr reads CONFIGPATH and parses argv at import time, and
+# setup_logging() opens ../logs. No config file is read until __init__ runs.
+os.environ.setdefault('CONFIGPATH', os.path.join(APP_DIR, '..', 'config', 'config.yml'))
+os.makedirs(os.path.join(APP_DIR, '..', 'logs'), exist_ok=True)
+sys.argv = sys.argv[:1]
+
+import stream_harvestarr  # noqa: E402
+
+
+class FakeResponse(object):
+
+    def json(self):
+        return {}
+
+
+class TestRescanSeriesPayload(unittest.TestCase):
+    """The command body must carry seriesId as an int."""
+
+    def setUp(self):
+        # Bypass __init__ (it needs a real config.yml) and set only what
+        # rescanseries reads.
+        self.client = object.__new__(stream_harvestarr.StreamHarvester)
+        self.client.base_url = 'http://sonarr:8989'
+        self.client.sonarr_api_version = 'api/v3'
+        self.sent = {}
+
+        def request_put(url, params=None, jsondata=None):
+            self.sent['url'] = url
+            self.sent['data'] = jsondata
+            return FakeResponse()
+
+        self.client.request_put = request_put
+
+    def test_series_id_sent_as_int(self):
+        self.client.rescanseries(314)
+        self.assertEqual(self.sent['data'], {'name': 'RescanSeries', 'seriesId': 314})
+
+    def test_numeric_string_is_coerced(self):
+        self.client.rescanseries('314')
+        self.assertIsInstance(self.sent['data']['seriesId'], int)
+
+    def test_posts_to_command_endpoint(self):
+        self.client.rescanseries(314)
+        self.assertEqual(self.sent['url'], 'http://sonarr:8989/api/v3/command')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows the Angular guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) — no docs impact

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: N/A

`rescanseries()` sends `"seriesId": str(series_id)`, but Sonarr v4 types it as a nullable int. Against `/api/v3/command`:

```
{"name":"RescanSeries","seriesId":"314"}  -> HTTP 500
  System.Text.Json.JsonException: The JSON value could not be converted to
  System.Nullable`1[System.Int32]. Path: $.seriesId
{"name":"RescanSeries","seriesId":314}    -> HTTP 201
```

The call sits right after a successful `ydl.download()`, so every download lands on disk and is never imported. The log still says `Downloaded`, which is what makes it easy to miss.

Separately, `development`'s `yt-dlp` floor is `>=2026.3.17` while `main` is on `>=2026.7.4` — #148 didn't make it back.

## What is the new behavior?

`seriesId` is sent as an int, so the rescan is accepted and the episode imports. The caller passes `ser['id']` straight from Sonarr so it is already an int; `int()` keeps it correct if a string ever reaches it.

`yt-dlp` floor bumped to `>=2026.7.4`, matching `main` and PyPI latest. The other six floors are already current.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

n/a