### PR TITLE
ci: run the test suite in CI and stop dependency bots bypassing development

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,11 +9,10 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    # Dependency PRs follow the same feature -> development -> main flow as
-    # human changes. Left unset, Dependabot opens against the default branch
-    # (main), so a merged floor bump ships in a release without ever reaching
-    # development -- that is the drift #148 produced.
+    # Dependency PRs follow feature -> development -> main like human changes.
+    # Left unset this defaults to main, where #148's floor bump landed and
+    # never came back to development.
     #
-    # Caveat: target-branch scopes this config to *version* updates. Security
-    # updates always target the default branch and are unaffected.
+    # Caveat: scopes this config to version updates; security updates always
+    # target the default branch.
     target-branch: "development"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,11 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    # Dependency PRs follow the same feature -> development -> main flow as
+    # human changes. Left unset, Dependabot opens against the default branch
+    # (main), so a merged floor bump ships in a release without ever reaching
+    # development -- that is the drift #148 produced.
+    #
+    # Caveat: target-branch scopes this config to *version* updates. Security
+    # updates always target the default branch and are unaffected.
+    target-branch: "development"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -129,10 +129,8 @@ jobs:
           exit 1
 
   unit-tests:
-    # The test/ suite imports the shipped modules out of app/ directly, so it
-    # runs on a plain Python job rather than inside the image. Deliberately
-    # not behind `needs: build-multiarch` -- it finishes in seconds and its
-    # signal is independent of the Docker build, so both report in parallel.
+    # Tests import app/ directly, so no container is needed. No needs: on
+    # build-multiarch -- independent signal, seconds vs QEMU minutes.
     name: Unit Tests (pytest)
     runs-on: ubuntu-latest
     defaults:
@@ -145,15 +143,13 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
-          # Mirror the Dockerfile base (python:3.14-alpine) so a
-          # version-specific break surfaces here and not only in the image.
+          # Mirror the Dockerfile base (python:3.14-alpine).
           python-version: '3.14'
           cache: 'pip'
 
       - name: Install dependencies
-        # pytest is installed here rather than added to requirements.txt: that
-        # file feeds the runtime image and is rewritten by the dependency-floor
-        # automation, and test-only tooling belongs in neither.
+        # pytest stays out of requirements.txt -- that file feeds the runtime
+        # image and the dependency-floor automation.
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt pytest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -127,3 +127,36 @@ jobs:
           done
           echo "YouTube extraction smoke test failed after 3 attempts." >&2
           exit 1
+
+  unit-tests:
+    # The test/ suite imports the shipped modules out of app/ directly, so it
+    # runs on a plain Python job rather than inside the image. Deliberately
+    # not behind `needs: build-multiarch` -- it finishes in seconds and its
+    # signal is independent of the Docker build, so both report in parallel.
+    name: Unit Tests (pytest)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          # Mirror the Dockerfile base (python:3.14-alpine) so a
+          # version-specific break surfaces here and not only in the image.
+          python-version: '3.14'
+          cache: 'pip'
+
+      - name: Install dependencies
+        # pytest is installed here rather than added to requirements.txt: that
+        # file feeds the runtime image and is rewritten by the dependency-floor
+        # automation, and test-only tooling belongs in neither.
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt pytest
+
+      - name: Run unit tests
+        run: python -m pytest test/ -q

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "baseBranches": [
+    "development"
   ]
 }


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows the Angular guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Two follow-ups noted on #153.

1. `ci.yaml` never invokes `test/` — it runs `build-multiarch` and the smoke
   test only. All 16 tests, including the suites for #150 and #151, give no
   regression protection.
2. Dependabot targets `main`, bypassing feature → development → main. #148
   bumped the yt-dlp floor on `main` and never reached `development` — the
   drift v1.9.9 cleans up. Renovate does the same: #87–#91 merged into `main`.

Issue Number: N/A

## What is the new behavior?

**`unit-tests` job** — Python 3.14 to match `python:3.14-alpine`. No `needs:`
on `build-multiarch`, so it reports in seconds instead of waiting on QEMU.
`pytest` is installed in the job, not `requirements.txt`, which feeds the
runtime image and the floor automation.

**Bots retargeted at `development`** — `target-branch` for Dependabot,
`baseBranches` for Renovate. Fixing only Dependabot would leave half the hole
open.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

- Verified on a bare clone in a fresh venv, and green here: `16 passed`.
- `target-branch` scopes Dependabot to *version* updates; security updates
  always target the default branch. GitHub behavior, not redirectable.
- No `paths` filter — the doc-only skip lives in `main.yaml` for pushes;
  `ci.yaml` runs on every PR.
- Floor bump check skipped per CLAUDE.md: `requirements.txt` was inside the
  4-hour freshness window.
- Needs `type: ci` + `area: workflows`; I lack label perms from a fork.