### PR TITLE
fix(extractor): never return a playlist from ytsearch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,6 +227,50 @@ non-obvious behaviors bit us in issue #114:
 If you ever feel tempted to "simplify" back to `.get('url')`, don't —
 re-read #114 first.
 
+### `matchtitle` is not a filter you can rely on
+
+**`matchtitle` does not remove every non-matching entry from
+`result['entries']`.** Two paths in `YoutubeDL` leave one in:
+
+- `_match_entry` returns early — before the title check — for any entry
+  whose `_type` is `url`/`url_transparent` and whose `ie_key` extractor
+  says `is_single_video()` is False. Every playlist in the results is
+  therefore unfiltered. A channel-search url
+  (`https://www.youtube.com/@CHANNEL/search?query=...`) interleaves
+  playlists with videos, and the VICE search had one at index 0.
+- When a *video* fails the title check in `process_video_result`,
+  yt-dlp `return`s the info dict rather than dropping it. It only
+  declines to download.
+
+Both come back looking exactly like a match. Handing one to
+`download()` is worse than finding nothing: the outtmpl is fixed per
+episode and `nooverwrites` is set, so yt-dlp writes the collection's
+first item into the episode's filename and every episode in the series
+becomes the same video. `noplaylist` does not help — it only strips
+`list=` from a `watch?v=...&list=...` url, not a bare
+`playlist?list=...`.
+
+So `ytsearch()` does its own two checks on each entry — `is_single_video()`
+and `title_matches()` — before accepting it. `title_matches()` reads the
+pattern back off the opts dict it passed to yt-dlp, so the two can't drift.
+
+### `upperescape` builds that pattern, and it is deliberately loose
+
+Punctuation is made optional to absorb human inconsistency between the
+Sonarr title and the upload title. Keep the optionality on *punctuation
+only*. The brackets around "(Part 3)" are optional; the words inside are
+not. Making the parenthetical itself optional collapses every part of a
+multi-part episode onto one regex, and they all resolve to the same video.
+Literal numbers are fenced with `(?<![0-9])`/`(?![0-9])` so "Part 1" can't
+claim "Part 10", while "(Part 1/5)" and "1 of 7" still match "(Part 1)".
+
+Two known gaps, asserted in `test/test_upperescape_parts.py` so a fix
+shows up as a test change: the optional-apostrophe class is ASCII-only
+(a curly apostrophe on the *site's* side won't match, since
+`_normalize_quotes` only touches the pattern), and the `\ AND\ ` →
+`(AND|&)` alternation is dead code (spaces are rewritten to `[\ ]*` on
+the preceding line, so the literal it looks for is already gone).
+
 ## Adding new architectures
 
 If a new platform is added to `main.yaml` / `cron.yaml`, also add it to

--- a/app/stream_harvestarr.py
+++ b/app/stream_harvestarr.py
@@ -33,6 +33,62 @@ SCANINTERVAL = 60
 # packaged for Alpine).  See issue #96.
 JS_RUNTIMES = {'deno': {'path': None}, 'node': {'path': None}}
 
+# yt-dlp results that are a *collection* rather than one video. Three shapes
+# reach ytsearch(): a resolved playlist ('playlist' / 'multi_video'), an
+# unresolved reference to one (_type 'url' whose url is a playlist or channel
+# page), and the top-level result for the configured url when nothing in it
+# matched. None of them may be handed to download(): with a fixed outtmpl and
+# nooverwrites, yt-dlp writes the collection's *first* item into the episode's
+# filename, so every episode gets the same wrong video.
+#
+# This is not theoretical. A channel-search url
+# (https://www.youtube.com/@CHANNEL/search?query=...) returns playlist entries
+# interleaved with videos, and YoutubeDL._match_entry deliberately skips
+# matchtitle for entries it can't confirm are a single video — so the playlist
+# sitting at index 0 was never filtered and won every episode.
+COLLECTION_TYPES = ('playlist', 'multi_video')
+# Markers that positively identify one video. Checked first so a legitimate
+# watch?v=ID&list=ID url isn't discarded along with the collections.
+VIDEO_URL_RE = re.compile(
+    r'(?:/watch\b|[?&]v=|/shorts/|youtu\.be/|/embed/)',
+    re.IGNORECASE
+)
+COLLECTION_URL_RE = re.compile(
+    r'(?:/playlist\b|[?&]list=|/@[^/]+/|/channel/|/user/|/c/|/results\b|/search\b)',
+    re.IGNORECASE
+)
+
+
+def is_single_video(entry):
+    """True when a yt-dlp result entry is one downloadable video."""
+    if entry.get('_type') in COLLECTION_TYPES:
+        return False
+    if entry.get('entries') is not None:
+        return False
+    url = entry.get('webpage_url') or entry.get('url') or ''
+    if VIDEO_URL_RE.search(url):
+        return True
+    return not COLLECTION_URL_RE.search(url)
+
+
+def title_matches(entry, matchtitle):
+    """Re-apply the matchtitle pattern to an entry ourselves.
+
+    yt-dlp is not a reliable filter here. When an entry fails matchtitle in
+    ``process_video_result`` it is returned anyway (just not downloaded), and
+    entries it can't confirm are a single video skip the check entirely. Both
+    land in ``result['entries']`` looking exactly like a match.
+
+    An entry with no title cannot be verified, so it is rejected: a missing
+    episode is recoverable, a wrong one silently isn't.
+    """
+    if not matchtitle:
+        return True
+    title = entry.get('title')
+    if not title:
+        return False
+    return re.search(matchtitle, title, re.IGNORECASE) is not None
+
 
 class StreamHarvester(object):
 
@@ -560,32 +616,39 @@ class StreamHarvester(object):
             if result is None:
                 logger.error('No metadata returned for {}'.format(playlist))
                 return False, ''
-            video_url = None
-            # Prefer webpage_url over url: yt-dlp's YouTube extractor only sets
-            # url when format selection picks a single non-merge format. HLS
-            # videos (most modern YouTube uploads) trigger ffmpeg audio+video
-            # merge — the "merged format" dict (YoutubeDL._merge) has
-            # requested_formats but no top-level url, so info_dict.update gives
-            # us an entry with .get('url') == None even though extraction
-            # succeeded. webpage_url is always set by the YouTube extractor
-            # directly; the .get('url') fallback covers other extractors that
-            # only populate url. See issue #114.
-            if 'entries' in result and len(result['entries']) > 0:
-                for entry in result['entries']:
-                    if entry is None:
-                        continue
-                    video_url = entry.get('webpage_url') or entry.get('url')
-                    if video_url:
-                        break
-            else:
-                video_url = result.get('webpage_url') or result.get('url')
-            if playlist == video_url:
-                return False, ''
-            if video_url is None:
-                logger.error('No video_url')
-                return False, ''
-            else:
+            # The pattern yt-dlp was given, re-read off the same opts dict so
+            # our check can never drift from the one it applied.
+            matchtitle = ydl_opts.get('matchtitle')
+            entries = result.get('entries')
+            candidates = list(entries) if entries else [result]
+            for entry in candidates:
+                if entry is None:
+                    continue
+                if not is_single_video(entry):
+                    logger.debug('  Skipping collection result: {}'.format(
+                        entry.get('title') or entry.get('url')
+                    ))
+                    continue
+                if not title_matches(entry, matchtitle):
+                    logger.debug('  Skipping title mismatch: {}'.format(entry.get('title')))
+                    continue
+                # Prefer webpage_url over url: yt-dlp's YouTube extractor only
+                # sets url when format selection picks a single non-merge
+                # format. HLS videos (most modern YouTube uploads) trigger
+                # ffmpeg audio+video merge — the "merged format" dict
+                # (YoutubeDL._merge) has requested_formats but no top-level
+                # url, so info_dict.update gives us an entry with
+                # .get('url') == None even though extraction succeeded.
+                # webpage_url is always set by the YouTube extractor directly;
+                # the .get('url') fallback covers other extractors that only
+                # populate url. See issue #114.
+                video_url = entry.get('webpage_url') or entry.get('url')
+                if not video_url or video_url == playlist:
+                    continue
+                logger.debug('  Matched "{}"'.format(entry.get('title')))
                 return True, video_url
+            logger.debug('  No single video matched in {} result(s)'.format(len(candidates)))
+            return False, ''
 
     def download(self, series, episodes):
         if len(series) != 0:

--- a/app/utils.py
+++ b/app/utils.py
@@ -94,9 +94,13 @@ def upperescape(string):
     string = re.escape(string)
     # Handle none to multiple spaces
     string = string.replace("\\ ", "[\\ ]*")
-    # Make parenthesis optional
-    string = string.replace("\\(", "([\\(]?")
-    string = string.replace("\\)", "[\\)]?)?")
+    # Make the parenthesis characters optional — but not what is inside them.
+    # This used to wrap the parenthetical in a group closed with '?', which
+    # made the whole thing optional: "Ricky Oyola (Part 1)" reduced to
+    # "RICKY OYOLA" and matched every part of the series, so each part
+    # downloaded whichever one the site listed first.
+    string = string.replace("\\(", "[\\(]?")
+    string = string.replace("\\)", "[\\)]?")
     # Make it look for and as whole or ampersands
     string = string.replace('\\ AND\\ ','\\ (AND|&)\\ ')
     # Make punctuation optional for human error
@@ -107,6 +111,11 @@ def upperescape(string):
     string = string.replace("\\?","([\\?]?)") # optional question mark
     string = string.replace(":","([:]?)") # optional colon
     string = re.sub("S\\\\", "([']?)"+"S\\\\", string) # optional belonging apostrophe (has to be last due to question mark)
+    # Fence every literal number so it can't match a longer one. Part numbers
+    # are the reason: without this, "Part 1" matches "Part 10" and a series
+    # numbered past nine assigns part 10's video to part 1. Lookarounds only,
+    # so "Part 1" still matches "Part 1/5" and "Part 1 of 5".
+    string = re.sub(r'(?<![0-9])([0-9]+)', r'(?<![0-9])\1(?![0-9])', string)
     return string
 
 

--- a/test/test_upperescape_parts.py
+++ b/test/test_upperescape_parts.py
@@ -1,0 +1,133 @@
+"""
+Unit tests for ``upperescape()`` on multi-part episode titles.
+
+``upperescape`` builds the regex handed to yt-dlp as ``matchtitle``, and
+yt-dlp ``re.search``es it against each candidate title. Two ways that used to
+go wrong for a series split into parts:
+
+1. The parenthetical was wrapped in a group closed with ``?``, which made its
+   *contents* optional, not just the brackets. "Ricky Oyola (Part 3)" reduced
+   to "RICKY OYOLA" and matched all five parts — so every part downloaded
+   whichever one the site happened to list first.
+2. A bare "Part 1" is a prefix of "Part 10", so a series numbered into double
+   digits mis-assigns the low-numbered parts.
+
+Titles here are real, from the VICE channel search and the Sonarr series they
+are matched against.
+"""
+import os
+import re
+import sys
+import unittest
+
+APP_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'app'))
+sys.path.insert(0, APP_DIR)
+
+os.environ.setdefault('CONFIGPATH', os.path.join(APP_DIR, '..', 'config', 'config.yml'))
+
+from utils import upperescape  # noqa: E402
+
+
+def matches(episode_title, candidate_title):
+    """Apply the pattern the way yt-dlp's matchtitle does."""
+    return re.search(upperescape(episode_title), candidate_title, re.IGNORECASE) is not None
+
+
+class TestParentheticalIsRequired(unittest.TestCase):
+
+    def test_part_matches_its_own_part(self):
+        self.assertTrue(matches(
+            'Ricky Oyola (Part 3/5)', "Epicly Later'd: Ricky Oyola (Part 3/5)"))
+
+    def test_part_does_not_match_a_sibling_part(self):
+        for other in (1, 2, 4, 5):
+            self.assertFalse(
+                matches('Ricky Oyola (Part 3/5)',
+                        "Epicly Later'd: Ricky Oyola (Part {}/5)".format(other)),
+                'part 3 matched part {}'.format(other))
+
+    def test_part_does_not_match_the_unnumbered_edit(self):
+        """The whole parenthetical used to be optional."""
+        self.assertFalse(matches(
+            'Ed Templeton (Part 2)', "Epicly Later'd: Ed Templeton"))
+
+    def test_brackets_themselves_stay_optional(self):
+        """Sites drop the brackets; that much is still tolerated."""
+        self.assertTrue(matches(
+            'Ethan Fowler (Part 2)', "Epicly Later'd: Ethan Fowler Part 2"))
+
+    def test_trailing_total_is_tolerated(self):
+        """Sonarr says "(Part 1)", the upload says "(Part 1/5)"."""
+        self.assertTrue(matches(
+            'Eric Dressen (Part 1)', "Epicly Later'd: Eric Dressen (Part 1/5)"))
+
+    def test_of_form_is_tolerated(self):
+        self.assertTrue(matches(
+            'Josh Kalis 1 of 7', 'Skateboarder Josh Kalis 1 of 7 - Epicly Later\'d - VICE'))
+
+
+class TestNumbersAreFenced(unittest.TestCase):
+
+    def test_part_1_does_not_match_part_10(self):
+        self.assertFalse(matches(
+            'Gino Iannucci - Pt. 1/10', 'Gino Iannucci - Pt. 10/10'))
+
+    def test_part_1_still_matches_part_1(self):
+        self.assertTrue(matches(
+            'Gino Iannucci - Pt. 1/10', "Gino Iannucci - Pt. 1/10 - Epicly Later'd"))
+
+    def test_part_10_matches_itself(self):
+        self.assertTrue(matches(
+            'Wild Ride  - Pt. 10/17', "Wild Ride - Pt. 10/17 - Epicly Later'd"))
+
+    def test_single_digit_does_not_match_two_digit_prefix(self):
+        self.assertFalse(matches('Guy Mariano Part 1', 'Guy Mariano Part 12'))
+
+
+class TestUnchangedBehaviour(unittest.TestCase):
+    """Titles without parts or numbers must match exactly as before."""
+
+    def test_plain_title_matches_decorated_upload(self):
+        self.assertTrue(matches(
+            'Ben Kadow', 'Ben Kadow: An American Original | Epicly Later’d'))
+
+    def test_apostrophes_stay_optional(self):
+        self.assertTrue(matches(
+            "Don 'Nuge' Nguyen",
+            "The Skate Legend Who Escaped Death & Saved Thrasher: Don 'Nuge' Nguyen | Epicly Later'd"))
+
+    def test_ascii_apostrophe_stays_optional(self):
+        self.assertTrue(matches(
+            "Tim O'Connor", "Pro Skater Tim OConnor Can Draw - Epicly Later'd - VICE"))
+
+    def test_unrelated_title_does_not_match(self):
+        self.assertFalse(matches('Ben Kadow', "Jamie Foy: Two-Time Skater | Epicly Later'd"))
+
+
+class TestKnownLimitations(unittest.TestCase):
+    """Pre-existing gaps, asserted so a future fix is a visible change.
+
+    Neither affects any title in the corpus this work was validated against,
+    so both are left alone rather than fixed speculatively.
+    """
+
+    def test_curly_apostrophe_in_the_site_title_does_not_match(self):
+        """_normalize_quotes runs on the pattern; the candidate is untouched.
+
+        The optional-apostrophe class is ASCII-only, so it can't skip a curly
+        one on the site's side.
+        """
+        self.assertFalse(matches(
+            "Tim O'Connor", "Pro Skater Tim O’Connor Can Draw - Epicly Later'd"))
+
+    def test_and_ampersand_alternation_is_dead_code(self):
+        r"""The '\ AND\ ' replacement never fires.
+
+        Spaces are rewritten to '[\ ]*' on the line above it, so the literal
+        it looks for is already gone by the time it runs.
+        """
+        self.assertFalse(matches('Gonz and Hosoi', 'Gonz & Hosoi'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_ytsearch_entry_selection.py
+++ b/test/test_ytsearch_entry_selection.py
@@ -1,0 +1,209 @@
+"""
+Unit tests for which entry ``ytsearch()`` is willing to return.
+
+yt-dlp's ``matchtitle`` cannot be trusted as the only filter. Two of its
+behaviours put non-matching entries into ``result['entries']`` looking exactly
+like a match:
+
+1. ``YoutubeDL._match_entry`` skips the title check for any entry it can't
+   confirm is a single video, which includes every playlist that turns up in a
+   channel-search result. A ``@CHANNEL/search?query=...`` url returns those
+   interleaved with the videos, and one of them sat at index 0.
+2. When an entry *does* fail matchtitle in ``process_video_result``, yt-dlp
+   returns the info dict anyway — it just declines to download it.
+
+Handing either to ``download()`` is worse than finding nothing: the outtmpl is
+fixed per episode and ``nooverwrites`` is set, so yt-dlp writes the
+collection's first item into the episode's filename and every episode in the
+series ends up as the same wrong video.
+
+Fixtures use real titles and ids from the VICE channel search that surfaced
+this, so the shapes are the ones yt-dlp actually produces.
+"""
+import os
+import sys
+import unittest
+
+APP_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'app'))
+sys.path.insert(0, APP_DIR)
+
+os.environ.setdefault('CONFIGPATH', os.path.join(APP_DIR, '..', 'config', 'config.yml'))
+os.makedirs(os.path.join(APP_DIR, '..', 'logs'), exist_ok=True)
+sys.argv = sys.argv[:1]
+
+import stream_harvestarr  # noqa: E402
+from utils import upperescape  # noqa: E402
+
+SEARCH_URL = "https://www.youtube.com/@VICE/search?query=epicly laterd"
+
+# Index 0 of the real search result: a playlist, never filtered by matchtitle.
+PLAYLIST_ENTRY = {
+    '_type': 'url',
+    'ie_key': 'YoutubeTab',
+    'id': 'PLDbSvEZka6GGm9cigiCJImOCKj6XZ9-gY',
+    'title': "Epicly Later'd",
+    'url': 'https://www.youtube.com/playlist?list=PLDbSvEZka6GGm9cigiCJImOCKj6XZ9-gY',
+}
+# The same playlist after yt-dlp resolved it, which is what actually lands in
+# entries once the reference is processed.
+RESOLVED_PLAYLIST_ENTRY = {
+    '_type': 'playlist',
+    'id': 'PLDbSvEZka6GGm9cigiCJImOCKj6XZ9-gY',
+    'title': "Epicly Later'd",
+    'entries': [],
+    'webpage_url': 'https://www.youtube.com/playlist?list=PLDbSvEZka6GGm9cigiCJImOCKj6XZ9-gY',
+}
+BEN_KADOW = {
+    'id': 'YrmakZiZTOE',
+    'title': 'Ben Kadow: An American Original | Epicly Later’d',
+    'webpage_url': 'https://www.youtube.com/watch?v=YrmakZiZTOE',
+}
+JAMIE_FOY = {
+    'id': 'bB5U9T9KZC8',
+    'title': "Jamie Foy: Two-Time Skater Of The Year And Fisherman | Epicly Later'd",
+    'webpage_url': 'https://www.youtube.com/watch?v=bB5U9T9KZC8',
+}
+
+
+class FakeYoutubeDL(object):
+    """Minimal yt_dlp.YoutubeDL stand-in usable as a context manager."""
+
+    def __init__(self, result=None):
+        self.result = result
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+    def extract_info(self, url, download=False):
+        return self.result
+
+
+class YtsearchTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self._real_ydl = stream_harvestarr.yt_dlp.YoutubeDL
+
+    def tearDown(self):
+        stream_harvestarr.yt_dlp.YoutubeDL = self._real_ydl
+
+    def ytsearch(self, result, episode_title=None):
+        stream_harvestarr.yt_dlp.YoutubeDL = lambda opts: FakeYoutubeDL(result)
+        opts = {'matchtitle': upperescape(episode_title)} if episode_title else {}
+        return stream_harvestarr.StreamHarvester.ytsearch(None, opts, SEARCH_URL)
+
+
+class TestCollectionEntriesRejected(YtsearchTestCase):
+    """A playlist or channel is never an episode."""
+
+    def test_unresolved_playlist_reference_is_skipped(self):
+        result = {'entries': [PLAYLIST_ENTRY, BEN_KADOW]}
+        self.assertEqual(
+            self.ytsearch(result, 'Ben Kadow'),
+            (True, 'https://www.youtube.com/watch?v=YrmakZiZTOE'),
+        )
+
+    def test_resolved_playlist_is_skipped(self):
+        result = {'entries': [RESOLVED_PLAYLIST_ENTRY, BEN_KADOW]}
+        self.assertEqual(
+            self.ytsearch(result, 'Ben Kadow'),
+            (True, 'https://www.youtube.com/watch?v=YrmakZiZTOE'),
+        )
+
+    def test_playlist_alone_is_not_found(self):
+        """The bug: nothing matched, so only the playlist was left."""
+        result = {'entries': [PLAYLIST_ENTRY]}
+        self.assertEqual(self.ytsearch(result, 'Lizard King'), (False, ''))
+
+    def test_search_page_result_is_not_found(self):
+        """The configured url resolving to itself is not an episode."""
+        result = {
+            '_type': 'playlist',
+            'title': 'VICE - Search',
+            'webpage_url': 'https://www.youtube.com/@VICE/search?query=epicly+laterd',
+        }
+        self.assertEqual(self.ytsearch(result, 'Lizard King'), (False, ''))
+
+    def test_channel_videos_tab_is_not_found(self):
+        result = {'entries': [{
+            '_type': 'url',
+            'ie_key': 'YoutubeTab',
+            'title': 'MILKY☆SUBWAY - Videos',
+            'url': 'https://www.youtube.com/@milkygalacticuniverse/videos',
+        }]}
+        self.assertEqual(self.ytsearch(result, 'MILKY☆SUBWAY'), (False, ''))
+
+    def test_watch_url_carrying_a_list_param_is_kept(self):
+        """A video inside a playlist is still a video."""
+        result = {'entries': [{
+            'title': 'Ben Kadow: An American Original | Epicly Later’d',
+            'webpage_url': 'https://www.youtube.com/watch?v=YrmakZiZTOE&list=PLDbSvEZka6GG',
+        }]}
+        found, url = self.ytsearch(result, 'Ben Kadow')
+        self.assertTrue(found)
+        self.assertIn('watch?v=YrmakZiZTOE', url)
+
+
+class TestTitleReverified(YtsearchTestCase):
+    """yt-dlp returns entries it rejected, so re-check the pattern."""
+
+    def test_entry_failing_matchtitle_is_skipped(self):
+        """process_video_result returns rejected entries rather than None."""
+        result = {'entries': [JAMIE_FOY, BEN_KADOW]}
+        self.assertEqual(
+            self.ytsearch(result, 'Ben Kadow'),
+            (True, 'https://www.youtube.com/watch?v=YrmakZiZTOE'),
+        )
+
+    def test_no_entry_matches_is_not_found(self):
+        result = {'entries': [JAMIE_FOY]}
+        self.assertEqual(self.ytsearch(result, 'Ben Kadow'), (False, ''))
+
+    def test_untitled_entry_is_rejected(self):
+        """Unverifiable is treated as not a match: missing beats wrong."""
+        result = {'entries': [{'webpage_url': 'https://youtu.be/mystery'}]}
+        self.assertEqual(self.ytsearch(result, 'Ben Kadow'), (False, ''))
+
+    def test_no_matchtitle_keeps_first_video(self):
+        """Without a pattern there is nothing to verify against."""
+        result = {'entries': [BEN_KADOW]}
+        self.assertEqual(
+            self.ytsearch(result),
+            (True, 'https://www.youtube.com/watch?v=YrmakZiZTOE'),
+        )
+
+
+class TestIsSingleVideo(unittest.TestCase):
+    """The url classifier, exercised directly on real url shapes."""
+
+    def test_video_urls(self):
+        for url in (
+            'https://www.youtube.com/watch?v=YrmakZiZTOE',
+            'https://youtu.be/YrmakZiZTOE',
+            'https://www.youtube.com/shorts/abc123',
+            'https://www.youtube.com/embed/abc123',
+        ):
+            self.assertTrue(
+                stream_harvestarr.is_single_video({'webpage_url': url}), url)
+
+    def test_collection_urls(self):
+        for url in (
+            'https://www.youtube.com/playlist?list=PLDbSvEZka6GG',
+            'https://www.youtube.com/@VICE/search?query=epicly+laterd',
+            'https://www.youtube.com/@milkygalacticuniverse/videos',
+            'https://www.youtube.com/channel/UCzn/videos',
+            'https://www.youtube.com/results?search_query=skate',
+        ):
+            self.assertFalse(
+                stream_harvestarr.is_single_video({'webpage_url': url}), url)
+
+    def test_unknown_extractor_url_is_allowed(self):
+        """Non-YouTube sites keep the pre-existing permissive behaviour."""
+        self.assertTrue(stream_harvestarr.is_single_video(
+            {'url': 'https://example.com/media/12345.mp4'}))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Problem

For a series configured with a channel-search url, every episode downloaded the same wrong video.

`ytsearch()` returns the first entry from `extract_info` that has a url. `matchtitle` is assumed to have removed everything else. It hasn't:

- `YoutubeDL._match_entry` returns *before* the title check for any entry whose `_type` is `url`/`url_transparent` and whose extractor's `is_single_video()` is False — so every playlist in the results is unfiltered. A `@CHANNEL/search?query=...` url interleaves playlists with videos.
- When a video *does* fail the title check in `process_video_result`, yt-dlp returns the info dict rather than dropping it; it only declines to download.

Both land in `result['entries']` looking like a match. Passing a playlist to `download()` is worse than finding nothing: the outtmpl is fixed per episode and `nooverwrites` is set, so yt-dlp writes the playlist's *first item* into the episode's filename. `noplaylist` doesn't help — it strips `list=` from `watch?v=...&list=...`, not from a bare `playlist?list=...`.

Observed on a VICE channel search where the "Epicly Later'd" playlist sat at index 0: three unrelated episodes all ended up as the same 39:26 video (the playlist's first item), each remuxed so the sizes matched exactly and only the mkv SegmentUIDs differed.

Live check against that search, for the "Casper Brooker" episode:

```
entries returned: 14        (13 playlists + 1 matching video)
before: playlist | Epicly Later'd | .../playlist?list=PLDbSvEZka6GGm9cigiCJImOCKj6XZ9-gY
after:  https://www.youtube.com/watch?v=33gGBLsAz8s
```

## Changes

1. **`ytsearch` rejects collection results** — `_type` in `playlist`/`multi_video`, a present `entries` key, or a url that looks like a playlist/channel/search page. A positive check for `watch?v=` / `youtu.be/` / `/shorts/` runs first so a legitimate `watch?v=ID&list=ID` isn't discarded. Unknown extractors keep the existing permissive behaviour.
2. **`ytsearch` re-applies `matchtitle` itself**, reading the pattern back off the opts dict it passed to yt-dlp so the two can't drift. An entry with no title is unverifiable and is rejected — a missing episode is recoverable, a wrong one silently isn't.
3. **`upperescape` no longer makes the parenthetical optional.** `"(Part 3)"` was wrapped in a group closed with `?`, so `"Ricky Oyola (Part 3)"` reduced to `RICKY OYOLA` and matched all five parts. Brackets stay optional; their contents don't. Literal numbers are fenced with lookarounds so `Part 1` can't claim `Part 10`, while `(Part 1/5)` and `1 of 7` still match `(Part 1)`.

`webpage_url or url` precedence is untouched (#114).

## Validation

- 49 tests pass, 27 of them new.
- `upperescape` change checked over 237 real Sonarr episode titles × 461 real candidate titles: 49 titles change their hit set, **no correct match is lost**, and every remaining top hit contains its episode title verbatim. Titles that now match nothing are ones whose exact part is genuinely absent from the source — previously they silently took part 1.
- `ytsearch` change verified live against the real search url, not a mock (above).

## Not covered

- An episode title that legitimately appears in a *different* series on the same channel still matches — e.g. Sonarr's "Max Schaaf" matches "From Vert Legend to Chopper Icon: Max Schaaf | Let It Kill You". Needs per-series scoping, not a matcher change.
- Where Sonarr models a multi-part documentary as one episode but the uploads are split into parts, the best case is part 1 and Sonarr marks the episode complete. That's a data-model mismatch.