### PR TITLE
fix(ci): don't publish a release before the image it points at exists

### DIFF
--- a/.github/workflows/_build-and-publish.yaml
+++ b/.github/workflows/_build-and-publish.yaml
@@ -55,7 +55,7 @@ jobs:
     name: Build & push to GHCR
     runs-on: ubuntu-latest
     outputs:
-      digest: ${{ steps.build.outputs.digest }}
+      digest: ${{ steps.build.outputs.digest || steps.build_retry.outputs.digest }}
       image: ${{ steps.vars.outputs.image }}
     steps:
       - name: Checkout
@@ -85,8 +85,15 @@ jobs:
         with:
           images: ${{ steps.vars.outputs.image }}
 
+      # The build itself is reliable; the *push* is not. GHCR answers with
+      # HTTP 403 "You have exceeded a secondary rate limit" under load, which
+      # fails the job after every arch has already been built and every layer
+      # exported. Retried once because it is transient and because by the
+      # second attempt the build is fully cached, so the retry re-attempts
+      # little more than the push itself.
       - name: Build and push to GHCR
         id: build
+        continue-on-error: true
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -103,6 +110,50 @@ jobs:
           # not subject to the per-branch 10GB GHA cache eviction policy.
           cache-from: type=registry,ref=${{ steps.vars.outputs.image }}/buildcache
           cache-to: type=registry,ref=${{ steps.vars.outputs.image }}/buildcache,mode=max
+
+      - name: Back off before retry
+        if: steps.build.outcome == 'failure'
+        run: |
+          echo "::warning::GHCR push failed; waiting 90s before one retry."
+          sleep 90
+
+      - name: Build and push to GHCR (retry)
+        id: build_retry
+        if: steps.build.outcome == 'failure'
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          sbom: true
+          provenance: mode=max
+          platforms: ${{ inputs.platforms }}
+          tags: |
+            ${{ steps.vars.outputs.image }}:${{ inputs.docker_tag }}
+            ${{ inputs.version_tag != '' && format('{0}:{1}', steps.vars.outputs.image, inputs.version_tag) || '' }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=${{ steps.vars.outputs.image }}/buildcache
+          cache-to: type=registry,ref=${{ steps.vars.outputs.image }}/buildcache,mode=max
+
+      # continue-on-error above means the job would otherwise report success
+      # when both attempts failed. Fail loudly instead, and guard against a
+      # push that "succeeded" without returning a digest -- downstream jobs
+      # reference the image by digest, so an empty one silently breaks them.
+      - name: Verify the image was pushed
+        env:
+          DIGEST: ${{ steps.build.outputs.digest || steps.build_retry.outputs.digest }}
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.build.outcome }}" = "failure" ] \
+             && [ "${{ steps.build_retry.outcome }}" != "success" ]; then
+            echo "::error::GHCR push failed on both attempts. Nothing was published." >&2
+            exit 1
+          fi
+          if [ -z "${DIGEST}" ]; then
+            echo "::error::Push reported success but produced no digest." >&2
+            exit 1
+          fi
+          echo "Pushed digest: ${DIGEST}"
 
   smoke-test:
     name: Smoke test pushed digest

--- a/.github/workflows/cron-build-rc.yaml
+++ b/.github/workflows/cron-build-rc.yaml
@@ -9,6 +9,15 @@ name: Cron - Weekly RC Build
 # retags by digest. If Thursday's promotion is blocked or fails, the
 # release still exists and users can pull :rc or :vX.Y.Z directly.
 #
+# That reasoning only covers Thursday failing. It did not cover *this*
+# workflow failing after the tag was already cut, which is what happened on
+# 2026-08-05: the version was bumped and the GitHub release published, then
+# the GHCR push hit a secondary rate limit. v1.10.1 was left advertised on
+# the releases page with no image behind it anywhere, and the smoke test --
+# the thing that would have caught it -- was skipped because it needs the
+# build. So the order is now: compute the version, build, smoke-test, and
+# only then tag and release. Nothing is announced before it exists.
+#
 # Note: GitHub `schedule:` triggers fire only against the default branch
 # (main), so this workflow always runs against main's HEAD. There is no
 # "cron on dev" -- by design.
@@ -24,11 +33,12 @@ permissions:
 
 jobs:
   prepare:
-    name: Prepare RC release metadata
+    name: Compute RC version
     runs-on: ubuntu-latest
     outputs:
       docker_tag: ${{ steps.tag.outputs.tag }}
       version_tag: ${{ steps.tag_version.outputs.new_tag }}
+      changelog: ${{ steps.tag_version.outputs.changelog }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -37,7 +47,7 @@ jobs:
         id: tag
         run: echo "tag=rc" >> "$GITHUB_OUTPUT"
 
-      - name: Bump version and push tag
+      - name: Compute next version
         id: tag_version
         uses: mathieudutour/github-tag-action@v6.2
         with:
@@ -46,26 +56,10 @@ jobs:
           # Bump every weekly run -- the rebake itself is the release.
           # See cron-restore-weekly-bump (#104) for rationale.
           default_bump: patch
-
-      - name: Create a GitHub release
-        if: steps.tag_version.outputs.new_tag != ''
-        uses: ncipollo/release-action@v1.21.0
-        with:
-          tag: ${{ steps.tag_version.outputs.new_tag }}
-          name: Release ${{ steps.tag_version.outputs.new_tag }}
-          body: |
-            Weekly maintenance rebake. No source changes since last release.
-
-            Picks up whatever's current upstream:
-            - `python:3.14-alpine` base image (security patches)
-            - Alpine packages (ffmpeg, curl, deno, nodejs)
-            - Python deps satisfying current `requirements.txt` constraints
-              (notably yt-dlp, which ships frequently to track YouTube changes)
-
-            Currently published as `:rc` and `:${{ steps.tag_version.outputs.new_tag }}`.
-            Will be promoted to `:latest` on Thursday after the 24h soak window.
-
-            ${{ steps.tag_version.outputs.changelog }}
+          # Compute only. The image needs the version to tag itself with, but
+          # the git tag must not exist until the image does -- see the header.
+          # The `release` job below pushes it once the build has succeeded.
+          dry_run: true
 
   build-and-publish:
     name: Build and publish RC
@@ -81,3 +75,54 @@ jobs:
     secrets:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
+
+  release:
+    name: Tag and release
+    # Only after the image is built, pushed, smoke-tested, and replicated.
+    # `needs` on the reusable workflow gates on all of its jobs, so a failure
+    # anywhere in it leaves no tag and no release behind.
+    needs: [prepare, build-and-publish]
+    if: needs.prepare.outputs.version_tag != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Push the version tag
+        env:
+          VERSION: ${{ needs.prepare.outputs.version_tag }}
+        run: |
+          set -euo pipefail
+          # Pushes the exact version `prepare` computed and the image was
+          # tagged with, rather than recomputing and risking a mismatch.
+          if git rev-parse -q --verify "refs/tags/${VERSION}" >/dev/null; then
+            echo "::notice::${VERSION} already exists; leaving it alone."
+            exit 0
+          fi
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${VERSION}" -m "Release ${VERSION}"
+          git push origin "${VERSION}"
+
+      - name: Create a GitHub release
+        uses: ncipollo/release-action@v1.21.0
+        with:
+          tag: ${{ needs.prepare.outputs.version_tag }}
+          name: Release ${{ needs.prepare.outputs.version_tag }}
+          # Idempotent, so re-running a partially failed run doesn't error.
+          allowUpdates: true
+          body: |
+            Weekly maintenance rebake. No source changes since last release.
+
+            Picks up whatever's current upstream:
+            - `python:3.14-alpine` base image (security patches)
+            - Alpine packages (ffmpeg, curl, deno, nodejs)
+            - Python deps satisfying current `requirements.txt` constraints
+              (notably yt-dlp, which ships frequently to track YouTube changes)
+
+            Published as `:rc` and `:${{ needs.prepare.outputs.version_tag }}`.
+            Will be promoted to `:latest` on Thursday after the 24h soak window.
+
+            ${{ needs.prepare.outputs.changelog }}

--- a/.github/workflows/cron-promote-rc.yaml
+++ b/.github/workflows/cron-promote-rc.yaml
@@ -72,6 +72,29 @@ jobs:
           echo "Resolved ${REPO}:rc -> ${DIGEST}"
           echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
 
+      - name: Refuse to promote a stale :rc
+        # A failed Wednesday build leaves :rc pointing at *last* week's image,
+        # which this workflow would otherwise happily re-promote to :latest --
+        # silently shipping a stale artifact while a newer release tag claims
+        # otherwise. If :rc already equals :latest there is nothing new to
+        # promote, and the right response is to fix Wednesday, not to proceed.
+        env:
+          REPO: ghcr.io/ryakel/stream-harvestarr
+          RC_DIGEST: ${{ steps.digest.outputs.digest }}
+        run: |
+          set -euo pipefail
+          if ! LATEST_DIGEST=$(regctl image digest "${REPO}:latest" 2>/dev/null); then
+            echo "::notice::no :latest yet -- first promotion, nothing to compare."
+            exit 0
+          fi
+          if [ "${RC_DIGEST}" = "${LATEST_DIGEST}" ]; then
+            echo "::error:::rc and :latest are already the same digest (${RC_DIGEST})." >&2
+            echo "::error::Nothing new to promote. Wednesday's RC build likely failed --" >&2
+            echo "::error::re-run it, confirm :rc moved, then re-run this workflow." >&2
+            exit 1
+          fi
+          echo ":rc (${RC_DIGEST}) differs from :latest (${LATEST_DIGEST}) -- promoting."
+
       - name: Promote :rc to :latest (GHCR + Docker Hub)
         env:
           DIGEST: ${{ steps.digest.outputs.digest }}


### PR DESCRIPTION
Fixes the bug behind the failed [weekly RC run on 2026-08-05](https://github.com/ryakel/stream-harvestarr/actions/runs/30991738931).

## What happened

The run bumped the version, pushed the git tag, and published the **v1.10.1 GitHub release** — then failed:

```
ERROR: failed to push ghcr.io/ryakel/stream-harvestarr:rc: denied: permission_denied: 403
"You have exceeded a secondary rate limit. Please wait a few minutes before you try again."
```

The build was fine. All four arches built, SBOMs generated, layers exported. It died on the final push.

But look at the step order:

| Step | Result |
|---|---|
| Bump version and push tag | ✅ |
| Create a GitHub release | ✅ |
| Build & push to GHCR | ❌ |
| Smoke test pushed digest | ⊘ skipped |
| Replicate to Docker Hub | ⊘ skipped |

**v1.10.1 is currently advertised on the releases page with no image behind it in any registry**, and the smoke test — the thing that would have caught it — was skipped precisely because it depends on the build that failed.

The workflow header reasoned about *Thursday's promotion* failing. It didn't consider *this* workflow failing after the tag was already cut.

There's a downstream consequence too: `cron-promote-rc` retags whatever `:rc` points at → `:latest`. With Wednesday's push failed, `:rc` is still last week's image, so Thursday would have promoted a stale artifact while a newer release tag claimed otherwise.

## Changes

### 1. Tag and release now follow the artifact (`cron-build-rc.yaml`)

`prepare` runs `github-tag-action` with `dry_run: true` — computing the version without creating it, since the image still needs a version to tag itself with. A new `release` job `needs: [prepare, build-and-publish]`, so it runs only once the image is pushed, smoke-tested, and replicated.

```
prepare  →  build-and-publish  →  release
(compute)   (build/smoke/push)    (tag + announce)
```

Because `build-and-publish` is a reusable workflow, gating on it gates on *all* its jobs — a failure anywhere leaves no tag and no release behind.

The release job pushes the exact version `prepare` computed rather than recomputing it, and uses `allowUpdates` so re-running a partially failed run isn't an error.

### 2. Retry the GHCR push once (`_build-and-publish.yaml`)

Secondary rate limits are transient and strike at push time, after the expensive work is done. By the retry the build is fully cached, so it re-attempts little more than the push itself. 90s backoff between attempts.

Two failure modes `continue-on-error` would otherwise hide, both now explicit:

- **Both attempts fail** → the job would report *success*. Now fails loudly.
- **Push succeeds but returns no digest** → downstream jobs address the image by digest, so an empty one breaks them silently. Now fails.

### 3. Refuse to promote a stale `:rc` (`cron-promote-rc.yaml`)

If `:rc` already equals `:latest` there is nothing new to promote, which means Wednesday failed. It now refuses and says to fix Wednesday rather than re-shipping a stale image.

## Verification

- All three workflows parse as valid YAML
- Job graph confirmed: `release` needs `[prepare, build-and-publish]`, gated on a non-empty version
- `prepare` reduced to Checkout / Set Docker tag / Compute next version — no tag or release creation remains
- Retry wiring confirmed: `continue-on-error` on attempt 1 only, both retry steps conditioned on its failure, digest output falls through to whichever attempt succeeded

## Not fixed here

**v1.10.1 is still orphaned.** This prevents recurrence; it doesn't retroactively publish the missing image. Re-running the failed job builds and pushes what that release points at. I can't trigger it — the API returns `403 Resource not accessible by integration` for workflow re-runs — so that click is needed on the run linked above.