### PR TITLE
fix(ci): apply the release-ordering fix to the latest publish path

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,5 +1,15 @@
 name: Docker Builder
 
+# Tag/release bookkeeping runs *after* the build, not before it. Publishing a
+# version before the image exists produced an orphaned v1.10.1 on the weekly
+# RC path (2026-08-05): the tag was pushed and the release announced, then the
+# GHCR push hit a secondary rate limit, and the smoke test that would have
+# caught it was skipped because it depends on the build. #161 fixed that in
+# cron-build-rc.yaml; this is the same defect in the path that publishes
+# `latest`, where it had simply not been hit yet.
+#
+# So: compute the version, build, smoke-test, and only then tag and release.
+
 on:
   workflow_dispatch:
   push:
@@ -27,6 +37,7 @@ jobs:
     outputs:
       docker_tag: ${{ steps.tag.outputs.tag }}
       version_tag: ${{ steps.tag_version.outputs.new_tag }}
+      changelog: ${{ steps.tag_version.outputs.changelog }}
       update_dockerhub_description: ${{ steps.flags.outputs.is_main }}
     steps:
       - name: Checkout
@@ -59,21 +70,17 @@ jobs:
             echo "is_main=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Bump version and push tag
+      - name: Compute next version
         if: github.ref == 'refs/heads/main'
         id: tag_version
         uses: mathieudutour/github-tag-action@v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           custom_release_rules: major:major,breaking:major,minor:minor,patch:patch,fix:patch
-
-      - name: Create a GitHub release
-        if: github.ref == 'refs/heads/main'
-        uses: ncipollo/release-action@v1.21.0
-        with:
-          tag: ${{ steps.tag_version.outputs.new_tag }}
-          name: Release ${{ steps.tag_version.outputs.new_tag }}
-          body: ${{ steps.tag_version.outputs.changelog }}
+          # Compute only. The image needs the version to tag itself with, but
+          # the git tag must not exist until the image does -- see the header.
+          # The `release` job below pushes it once the build has succeeded.
+          dry_run: true
 
   build-and-publish:
     name: Build and publish
@@ -87,3 +94,45 @@ jobs:
     secrets:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
+
+  release:
+    name: Tag and release
+    # Only after the image is built, pushed, smoke-tested, and replicated.
+    # `needs` on the reusable workflow gates on all of its jobs, so a failure
+    # anywhere in it leaves no tag and no release behind.
+    #
+    # Restricted to main: this workflow also runs for `development` (:dev) and
+    # for tag pushes, neither of which cuts a release.
+    needs: [prepare, build-and-publish]
+    if: github.ref == 'refs/heads/main' && needs.prepare.outputs.version_tag != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Push the version tag
+        env:
+          VERSION: ${{ needs.prepare.outputs.version_tag }}
+        run: |
+          set -euo pipefail
+          # Pushes the exact version `prepare` computed and the image was
+          # tagged with, rather than recomputing and risking a mismatch.
+          if git rev-parse -q --verify "refs/tags/${VERSION}" >/dev/null; then
+            echo "::notice::${VERSION} already exists; leaving it alone."
+            exit 0
+          fi
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${VERSION}" -m "Release ${VERSION}"
+          git push origin "${VERSION}"
+
+      - name: Create a GitHub release
+        uses: ncipollo/release-action@v1.21.0
+        with:
+          tag: ${{ needs.prepare.outputs.version_tag }}
+          name: Release ${{ needs.prepare.outputs.version_tag }}
+          # Idempotent, so re-running a partially failed run doesn't error.
+          allowUpdates: true
+          body: ${{ needs.prepare.outputs.changelog }}


### PR DESCRIPTION
Follow-up to #161, which fixed this same defect in the weekly RC path. `main.yaml` — the workflow that publishes `latest` — still had it.

## The defect

`prepare` bumps the version, pushes the git tag, and publishes the GitHub release, and only then does `build-and-publish` run:

```
prepare (tag + release)  →  build-and-publish (build/push/smoke)
```

So a GHCR secondary rate limit during a promotion produces exactly what happened to v1.10.1 on 2026-08-05: a release advertised on the releases page with no image behind it in any registry, and the smoke test skipped because it depends on the build that failed.

It hasn't been hit here only because promotions are infrequent and hand-triggered, where the weekly cron runs unattended. This is the path that publishes `latest`, so it's the worse place to leave it.

## The fix

Same shape as #161:

```
prepare  →  build-and-publish  →  release
(compute)   (build/smoke/push)    (tag + announce)
```

`prepare` computes the version with `dry_run: true` — the image still needs a version to tag itself with — and a new `release` job, gated on both `prepare` and the entire build workflow, pushes the tag and creates the release once the image exists and passed its smoke test. Because `build-and-publish` is a reusable workflow, gating on it gates on all of its jobs.

The release job pushes the exact version `prepare` computed rather than recomputing, and uses `allowUpdates` so re-running a partially failed run isn't an error.

## The `:dev` path is unchanged

This workflow also runs for `development` and for tag pushes, neither of which cuts a release. The `release` job keeps the existing `refs/heads/main` restriction, and the version step was already gated on main — so on a `development` push `version_tag` is empty exactly as before, and the reusable workflow already handles that.

## Verification

- YAML valid; job graph confirmed: `release` needs `[prepare, build-and-publish]`, gated on `refs/heads/main` **and** a non-empty version
- `prepare` reduced to Checkout / Set Docker tag / Set flags / Compute next version — no tag or release creation remains
- `changelog` threaded through as a `prepare` output so the release body is unchanged
- Dependency floors checked per CLAUDE.md (237h since last touch); all seven already at PyPI latest, no bump needed

## Note on #162

That promotion is open against the current `development` tip. Once this merges, #162 picks it up automatically and carries both ordering fixes in one release.